### PR TITLE
DeskClock: Ensure ringtone is playing when starting the crescendo effect

### DIFF
--- a/src/com/android/deskclock/AsyncRingtonePlayer.java
+++ b/src/com/android/deskclock/AsyncRingtonePlayer.java
@@ -435,6 +435,9 @@ public final class AsyncRingtonePlayer {
         /** The current ringtone. Only used by the ringtone thread. */
         private Ringtone mRingtone;
 
+        /** The ringtone playback attempts counter. */
+        private int mRingtonePlayRetries = 0;
+
         /** The method to adjust playback volume; cannot be null. */
         private Method mSetVolumeMethod;
 
@@ -603,11 +606,33 @@ public final class AsyncRingtonePlayer {
         public boolean adjustVolume(Context context) {
             checkAsyncRingtonePlayerThread();
 
-            // If ringtone is absent or not playing, ignore volume adjustment.
-            if (mRingtone == null || !mRingtone.isPlaying()) {
+            // If ringtone is absent, ignore volume adjustment.
+            if (mRingtone == null) {
                 mCrescendoDuration = 0;
                 mCrescendoStopTime = 0;
                 return false;
+            }
+
+            // If ringtone is not playing, to avoid being muted forever recheck
+            // to ensure reliability.
+            if (!mRingtone.isPlaying()) {
+                if (mRingtonePlayRetries < 10) {
+                    mRingtonePlayRetries++;
+                    // Reuse the crescendo messaging looper to return here
+                    // again.
+                    return true;
+                }
+
+                mRingtonePlayRetries = 0;
+                mCrescendoDuration = 0;
+                mCrescendoStopTime = 0;
+                return false;
+            }
+
+            if (mRingtonePlayRetries > 0) {
+                mRingtonePlayRetries = 0;
+                // Compute again the time at which the crescendo will stop.
+                mCrescendoStopTime = Utils.now() + mCrescendoDuration;
             }
 
             // If the crescendo is complete set the volume to the maximum; we're done.


### PR DESCRIPTION
**The bug:**
No alarm sound when `Gradually increase volume` option is set. Same feature works as expected in Google Clock app from Playstore. Also, I can't reproduce it on any LOS version, but I was always able to reproduce it starting from crDroid 6 (didn't checked further down).

**To reproduce:**
1. Set `Gradually increase volume` for alarm
2. Set alarm
3. Hear no audio at all when alarm is fired

**Solution:**
The crescendo effect is aborted because `mRingtone.isPlaying()` is always `false` for around 50-100ms after `mRingtone.play()` is called, this leaves the alarm audio muted forever. The root cause of such latency seems to come from some old patch, which is backported in every new crDroid version.